### PR TITLE
Markdown table is difficult to read - Convert to HTML

### DIFF
--- a/help/admin/c-data-governance/gdpr-labeling-example.md
+++ b/help/admin/c-data-governance/gdpr-labeling-example.md
@@ -30,72 +30,332 @@ Suppose you have the following hit data:
 
 If I submit an access request, the summary file will contain the values indicated in the table below. A request may return only a device file, only a person file or one of each. Two summary files are only returned if a person ID is used and expandIds is true.
 
-| API Values | API Values | Returned File Type | Data in <br> Summary Access File | Data in <br> Summary Access File | Data in <br> Summary Access File | Data in <br> Summary Access File | Data in <br> Summary Access File |
-|--- |--- |--- |---|---|---|---|---|
-| **Namespace/ID** | **expandIDs** | | **MyProp1** | **Visitor ID** | **MyEvar1** | **MyEvar2** | **MyEvar3** |
-| AAID=77 | false | device | Variable not present | 77 | Variable not present | M, P | X, W |
-| AAID=77 |true | device | Variable not present | 77 | Variable not present | M, P | X, W |
-| user=Mary | false | person | Mary | 77, 88, 99 | A, B, C | M, N, O | X, Y, Z |
-| user=Mary | true | person | Mary | 77, 88, 99 | A, B, C | M, N, O | X, Y, Z |
-| user=Mary | true | device | not present | 77, 88 | not present | N, P | U, W |
-| user=Mary AAID=66 | true | person | Mary | 77, 88, 99 | A, B, C | M, N, O | X, Y, Z |
-| user=Mary AAID=66 | true | device | not present | 66, 77, 88 | not present | N, P | U, W, Z |
-| xyz=X | false | device | not present | 55, 77 | not present | M, R | X |
-| xyz=X | true | device | not present | 55, 77 | not present | M, P, R | W, X |
-
+<table>
+  <tr>
+    <th colspan="2" style="text-align:center">API Values</th>
+    <th rowspan="2">Returned<br>File Type</th>
+    <th colspan="5" style="text-align:center">Data in Summary Access File</th>
+  </tr>
+  <tr>
+    <th>Namespace/ID</th>
+    <th>expandIDs</th>
+    <th>MyProp1</th>
+    <th>Visitor ID</th>
+    <th>MyEvar1</th>
+    <th>MyEvar2</th>
+    <th>MyEvar3</th>
+  </tr>
+  <tr>
+    <td>AAID=77</td>
+    <td>false</td>
+    <td>device</td>
+    <td>not present</td>
+    <td>77</td>
+    <td>not present</td>
+    <td>M, P</td>
+    <td>X, W</td>
+  </tr>
+  <tr>
+    <td>AAID=77</td>
+    <td>true</td>
+    <td>device</td>
+    <td>not present</td>
+    <td>77</td>
+    <td>not present</td>
+    <td>M, P</td>
+    <td>X, W</td>
+  </tr>
+  <tr>
+    <td>user=Mary</td>
+    <td>false</td>
+    <td>person</td>
+    <td>Mary</td>
+    <td>77, 88, 99</td>
+    <td>A, B, C</td>
+    <td>M, N, O</td>
+    <td>X, Y, Z</td>
+  </tr>
+  <tr>
+    <td rowspan="2">user=Mary</td>
+    <td rowspan="2">true</td>
+    <td>person</td>
+    <td>Mary</td>
+    <td>77, 88, 99</td>
+    <td>A, B, C</td>
+    <td>M, N, O</td>
+    <td>X, Y, Z</td>
+  </tr>
+  <tr>
+    <td>device</td>
+    <td>not present</td>
+    <td>77, 88</td>
+    <td>A, B, C</td>
+    <td>N, P</td>
+    <td>U, W</td>
+  </tr>
+  <tr>
+    <td rowspan="2">user=Mary<br>AAID=66</td>
+    <td rowspan="2">true</td>
+    <td>person</td>
+    <td>Mary</td>
+    <td>77, 88, 99</td>
+    <td>A, B, C</td>
+    <td>M, N, O</td>
+    <td>X, Y, Z</td>
+  </tr>
+  <tr>
+    <td>device</td>
+    <td>not present</td>
+    <td>66, 77, 88</td>
+    <td>A, B, C</td>
+    <td>N, P</td>
+    <td>U, W, Z</td>
+  </tr>
+  <tr>
+    <td>xyz=X</td>
+    <td>false</td>
+    <td>device</td>
+    <td>not present</td>
+    <td>55, 77</td>
+    <td>not present</td>
+    <td>M, R</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>xyz=X</td>
+    <td>true</td>
+    <td>device</td>
+    <td>not present</td>
+    <td>55, 77</td>
+    <td>not present</td>
+    <td>M, P, R</td>
+    <td>W, X</td>
+  </tr>
+</table>
 Notice that the setting for expandIDs does not make any difference to the output when a cookie ID is used.
 
-## Sample Delete Request
+## Sample Delete Requests
 
 With a delete request using the API values in the first row of the table, the hit table will be updated to look something like this: 
 
-|AAID=77 expandIDs value <br> does not matter | AAID=77 expandIDs value <br> does not matter | AAID=77 expandIDs value <br> does not matter | AAID=77 expandIDs value <br> does not matter | AAID=77 expandIDs value <br> does not matter |
-|---|---|---|---|---|
-| **MyProp1** | **AAID** | **MyEvar1** | **MyEvar2** | **MyEvar3** |
-|Mary|42|A|Privacy-7398|Privacy-9152|
-|Mary|88|B|N|Y|
-|Mary|99|C|O|Z|
-|John|42|D|Privacy-1866|Privacy-8216|
-|John|88|E|N|U|
-|John|44|F|Q|V|
-|John|55|G|R|X|
-|Alice|66|A|N|W|
+<table>
+  <tr>
+    <th colspan="5" style="text-align:center">AAID=77 <br>(expandIDs value does not matter)</th>
+  </tr>
+  <tr>
+    <th>MyProp1</th>
+    <th>AAID</th>
+    <th>MyEvar1</th>
+    <th>MyEvar2</th>
+    <th>MyEvar3</th>
+  </tr>
+  <tr>
+    <td>Mary</td>
+    <td>42</td>
+    <td>A</td>
+    <td>Privacy-7398</td>
+    <td>Privacy-9152</td>
+  </tr>
+  <tr>
+    <td>Mary</td>
+    <td>88</td>
+    <td>B</td>
+    <td>N</td>
+    <td>Y</td>
+  </tr>
+  <tr>
+    <td>Mary</td>
+    <td>99</td>
+    <td>C</td>
+    <td>O</td>
+    <td>Z</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>42</td>
+    <td>D</td>
+    <td>Privacy-1866</td>
+    <td>Privacy-8216</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>88</td>
+    <td>E</td>
+    <td>N</td>
+    <td>U</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>44</td>
+    <td>F</td>
+    <td>Q</td>
+    <td>V</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>55</td>
+    <td>G</td>
+    <td>R</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>Alice</td>
+    <td>66</td>
+    <td>A</td>
+    <td>N</td>
+    <td>Z</td>
+  </tr>
+</table>
 
 >[!NOTE]
 >
 >Only cells on rows containing AAID = 77 and a DEL-DEVICE label are impacted.
 
-|user=Mary <br> expandIDs=false|user=Mary <br> expandIDs=false|user=Mary <br> expandIDs=false|user=Mary <br> expandIDs=false|user=Mary <br> expandIDs=false|
-|--- |---|---|---|---|
-|**MyProp1**|**AAID**|**MyEvar1**|**MyEvar2**|**MyEvar3**|
-|Privacy-0523|77|Privacy-1866|Privacy-3681|X|
-|Privacy-0523|88|Privacy-2178|Privacy-1975|Y|
-|Privacy-0523|99|Privacy-9045|Privacy-2864|Z|
-|John|77|D|P|W|
-|John|88|E|N|U|
-|John|44|F|Q|V|
-|John|55|G|R|X|
-|Alice|66|A|N|W|
+<table>
+  <tr>
+    <th colspan="5" style="text-align:center">user=Mary <br> expandIDs=false</th>
+  </tr>
+  <tr>
+    <th>MyProp1</th>
+    <th>AAID</th>
+    <th>MyEvar1</th>
+    <th>MyEvar2</th>
+    <th>MyEvar3</th>
+  </tr>
+  <tr>
+    <td>Privacy-0523</td>
+    <td>77</td>
+    <td>Privacy-1866</td>
+    <td>Privacy-3681</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>Privacy-0523</td>
+    <td>88</td>
+    <td>Privacy-2178</td>
+    <td>Privacy-1975</td>
+    <td>Y</td>
+  </tr>
+  <tr>
+    <td>Privacy-0523</td>
+    <td>99</td>
+    <td>Privacy-9045</td>
+    <td>Privacy-2864</td>
+    <td>Z</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>77</td>
+    <td>D</td>
+    <td>P</td>
+    <td>W</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>88</td>
+    <td>E</td>
+    <td>N</td>
+    <td>U</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>44</td>
+    <td>F</td>
+    <td>Q</td>
+    <td>V</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>55</td>
+    <td>G</td>
+    <td>R</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>Alice</td>
+    <td>66</td>
+    <td>A</td>
+    <td>N</td>
+    <td>Z</td>
+  </tr>
+</table>
 
 >[!NOTE]
 >
 >Only cells on rows containing user=Mary and a DEL-PERSON label are impacted. Also, in practice the variable containing A_ID would probably be a prop or eVar and its replacement value would be a string starting with "Privacy-", followed by a random number (GUID), rather than replacing the numeric value with a different, random numeric value.
 
-|user=Mary <br> expandIDs=true|user=Mary <br> expandIDs=true|user=Mary <br> expandIDs=true|user=Mary <br> expandIDs=true|user=Mary <br> expandIDs=true|
-|--- |---|---|---|---|
-|**MyProp1**|**AAID**|**MyEvar1**|**MyEvar2**|**MyEvar3**|
-|Privacy-5782|09|Privacy-0859|Privacy-8183|Privacy-9152|
-|Privacy-5782|16|Privacy-6104|Privacy-2911|Privacy-6821|
-|Privacy-5782|83|Privacy-2714|Privacy-0219|Privacy-4395|
-|John|09|D|Privacy-8454|Privacy-8216|
-|John|16|E|Privacy-2911|Privacy-2930|
-|John|44|F|Q|V|
-|John|55|G|R|X|
-|Alice|66|A|N|W|
+<table>
+  <tr>
+    <th colspan="5" style="text-align:center">user=Mary <br> expandIDs=true</th>
+  </tr>
+  <tr>
+    <th>MyProp1</th>
+    <th>AAID</th>
+    <th>MyEvar1</th>
+    <th>MyEvar2</th>
+    <th>MyEvar3</th>
+  </tr>
+  <tr>
+    <td>Privacy-5782</td>
+    <td>09</td>
+    <td>Privacy-0859</td>
+    <td>Privacy-8183</td>
+    <td>Privacy-9152</td>
+  </tr>
+  <tr>
+    <td>Privacy-5782</td>
+    <td>16</td>
+    <td>Privacy-6104</td>
+    <td>Privacy-2911</td>
+    <td>Privacy-6821</td>
+  </tr>
+  <tr>
+    <td>Privacy-5782</td>
+    <td>83</td>
+    <td>Privacy-2714</td>
+    <td>Privacy-0219</td>
+    <td>Privacy-4395</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>09</td>
+    <td>D</td>
+    <td>Privacy-8454</td>
+    <td>Privacy-8216</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>16</td>
+    <td>E</td>
+    <td>Privacy-2911</td>
+    <td>Privacy-2930</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>44</td>
+    <td>F</td>
+    <td>Q</td>
+    <td>V</td>
+  </tr>
+  <tr>
+    <td>John</td>
+    <td>55</td>
+    <td>G</td>
+    <td>R</td>
+    <td>X</td>
+  </tr>
+  <tr>
+    <td>Alice</td>
+    <td>66</td>
+    <td>A</td>
+    <td>N</td>
+    <td>Z</td>
+  </tr>
+</table>
 
-Note the following:
-
-* Cells on rows containing `user=Mary` and a `DEL-DEVICE` or `DEL-PERSON` label are impacted, as well as cells with a `DEL-DEVICE` label on rows containing any Visitor ID that occurred on a row containing `user=Mary`.
-* `MyEvar2` in the fourth and fifth rows is updated because these rows contain the same Visitor ID values as those on the first and second rows, so ID expansion includes them for device-level deletes.
-* The values of `MyEvar2` in rows two and five match both before and after the delete, but after the delete no longer matches the value N that occurs in the last row, because that row was not updated as part of the delete request.
-* `MyEvar3` behaves very differently than it did without ID expansion, because without ID expansion, no `ID-DEVICES` matched. Now `AAID` matches on the first five rows.
+>[!NOTES]
+>* Cells on rows containing `user=Mary` and a `DEL-DEVICE` or `DEL-PERSON` label are impacted, as well as cells with a `DEL-DEVICE` label on rows containing any Visitor ID (AAID) that occurred on a row containing `user=Mary`. 
+>* The expandIDs setting does not expand to the call to include values present in MyEvar3, which has an ID-DEVICE label, when `user=Mary`. ExpandIDs only expands to include Visitor IDs (AAIDs in this example, but also the ECID) on rows where `user=Mary`.
+>* `MyEvar2` in the fourth and fifth rows is updated because these rows contain the same Visitor ID values as those on the first and second rows, so ID expansion includes them for device-level deletes.
+>* The values of `MyEvar2` in rows two and five match both before and after the delete, but after the delete no longer matches the value N that occurs in the last row, because that row was not updated as part of the delete request.
+>* `MyEvar3` behaves very differently than it did without ID expansion, because without ID expansion, no `ID-DEVICES` matched. Now `AAID` matches on the first five rows.


### PR DESCRIPTION
Updated tables to use HTML rather than markdown so that cells can be merged where appropriate.
Fixed bug in last three tables where cell value should have been "Z" rather than "W"
Updated Notes after last table, including a new not.