### PR TITLE
Update adobe-campaign.md

### DIFF
--- a/help/integrate/adobe-campaign.md
+++ b/help/integrate/adobe-campaign.md
@@ -54,7 +54,6 @@ The following **metrics** are available from Campaign in Adobe Analytics report 
 * Adobe Campaign Sent 
 * Adobe Campaign Opened 
 * Adobe Campaign Clicked 
-* Adobe Campaign Processed 
 * Adobe Campaign Delivered 
 * Adobe Campaign Unique Open 
 * Adobe Campaign Unique Click 


### PR DESCRIPTION
Engineering communicated that this metric is not sent from AC to AA.

Engineering has determined that the “Adobe Campaign Processed” field is not a metric that is sent to AA so it will always be shown as