### PR TITLE
Correcting Example 1 anchor tag href attribute

### DIFF
--- a/help/analyze/activity-map/activitymap-link-tracking/link-tracking-faq.md
+++ b/help/analyze/activity-map/activitymap-link-tracking/link-tracking-faq.md
@@ -78,7 +78,7 @@ b. Via the `s_objectID` variable. Example:
 
   ```
 
-    <a hef="/home>Home</a>
+    <a href="/home>Home</a>
 
   ```
 


### PR DESCRIPTION
Updated the Example 1 attribute from 'hef' to 'href'.