### PR TITLE
Say to exclude visit_num=0 in datafeeds-calculate.md

### DIFF
--- a/help/export/analytics-data-feed/c-df-contents/datafeeds-calculate.md
+++ b/help/export/analytics-data-feed/c-df-contents/datafeeds-calculate.md
@@ -11,7 +11,7 @@ Describes how to calculate common metrics using data feeds.
 
 >[!NOTE]
 >
->Hits normally excluded from Adobe Analytics are included in data feeds. Use `exclude_hit = 0` to remove excluded hits from queries on raw data. Data sourced data are also included in data feeds. If you want to exclude data sources, exclude all rows with `hit_source = 5,7,8,9`.
+>Hits normally excluded from Adobe Analytics are included in data feeds. Use `exclude_hit = 0` and `visit_num != 0` to remove excluded hits from queries on raw data. Data sourced data are also included in data feeds. If you want to exclude data sources, exclude all rows with `hit_source = 5,7,8,9`.
 
 ## Page views
 


### PR DESCRIPTION
Since the Visit Number is documented [here](https://experienceleague.adobe.com/docs/analytics/components/dimensions/visit-number.html?lang=en) to start at 1, visit_num=0 should be excluded from metrics calculation. This was confirmed in Support Case [E-001099678](https://adminconsole.adobe.com/F0EF5E09512D2CD20A490D4D@AdobeOrg/support/support-cases/E-001099678)